### PR TITLE
Disable IndentationStyle

### DIFF
--- a/misc/.rubocop.yml
+++ b/misc/.rubocop.yml
@@ -69,3 +69,6 @@ Naming/MethodParameterName:
 
 Metrics/BlockLength:
   Enabled: false
+
+Layout/IndentationStyle:
+  Enabled: false


### PR DESCRIPTION
Open bug: https://github.com/rubocop/rubocop/issues/9373 . Rubocop linting with tabs is not available yet.