### PR TITLE
add ":show" to ratings resources

### DIFF
--- a/english/week8.md
+++ b/english/week8.md
@@ -1073,7 +1073,7 @@ With the modified templates ready, let's update the `routes.rb` file to handle t
 **/app/config/routes.rb**
 
 ```ruby
-resources :ratings, only: [:index, :new, :create]
+resources :ratings, only: [:index, :new, :create, :show]
 delete 'ratings', to: 'ratings#destroy'
 ```
 


### PR DESCRIPTION
Otherwise partial _ratings.html.erb <%= link_to "#{rating.score} #{rating.beer.name}", rating, data: { turbo_frame: "rating_details" }  %> throws routing error.