### PR TITLE
removed programmableweb.com from week5, site does not exist

### DIFF
--- a/english/week5.md
+++ b/english/week5.md
@@ -5,9 +5,7 @@ You will continue to develop your application from the point you arrived at the 
 
 A great part of modern Internet services makes use of open interfaces which provides useful data to enrich applications functionality.
 
-Interfaces for beers are also available, try to search for beer at http://www.programmableweb.com/ 
-
-The best interface among the ones available seems to be  Beermapping API (see http://www.programmableweb.com/api/beer-mapping ja http://beermapping.com/api/), which makes it possible to search for beer restaurants.
+The best interface among the ones available seems to be  Beermapping API <http://beermapping.com/api/>, which makes it possible to search for beer restaurants.
 
 Applications which make use of beermaping API need a singular API key. You can retrieve a key at https://beermapping.com/api/, after logging in to the page (after logging in edit the url in your browser's address bar back to https://beermapping.com/api/). This is a common procedure in use for the larger part of modern free interfaces.
 

--- a/web/viikko5.md
+++ b/web/viikko5.md
@@ -4,9 +4,7 @@ Jatkamme sovelluksen rakentamista siitä, mihin jäimme viikon 4 lopussa. Allaol
 
 Suuri osa internetin palveluista hyödyntää nykyään joitain avoimia rajapintoja, joiden tarjoaman datan avulla sovellukset voivat rikastaa omaa toiminnallisuuttaan.
 
-Myös oluihin liittyviä avoimia rajapintoja on tarjolla, ks. https://www.programmableweb.com/ hakusanalla beer
-
-Käyttöömme valikoituu Beermapping API (ks. <https://www.programmableweb.com/api/beer-mapping> ja <https://beermapping.com/api/>), joka tarjoaa mahdollisuuden oluita tarjoilevien ravintoloiden tietojen etsintään.
+Käyttöömme valikoituu Beermapping API <https://beermapping.com/api/>, joka tarjoaa mahdollisuuden oluita tarjoilevien ravintoloiden tietojen etsintään.
 
 Beermapingin API:a käyttävät sovellukset tarvitsevat yksilöllisen API-avaimen. Saat avaimen sivulta https://beermapping.com/api/ kirjauduttuasi ensin sivulle (kirjautumisen jälkeen vaihda selaimen osoiteriviltä osoite takaisin muotoon https://beermapping.com/api/). Vastaava käytäntö on olemassa hyvin suuressa osassa nykyään tarjolla olevissa avoimissa rajapinnoissa.
 


### PR DESCRIPTION
The site programmableweb.com does not exist anymore, (https://www.mulesoft.com/programmableweb). Removed the two mentions in the week5 material in the finnish and english versions.